### PR TITLE
Bulk get users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ While Lantern is ready to use out-of-the-box without the need for any deployment
 ## Table of Contents
 
 - [API Docs](#api-docs)
+  - [**GET** `/api/v1/users`](#get-apiv1users)
   - [**GET** `/api/v1/users/:id`](#get-apiv1usersid)
   - [WebSocket](#websocket)
 - [KV Storage](#kv-storage)
@@ -30,6 +31,112 @@ While Lantern is ready to use out-of-the-box without the need for any deployment
 ---
 
 ## API Docs
+
+#### GET `/api/v1/users`
+
+Retrieve the data of users with the specified IDs.
+
+##### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `user_ids` | string | The IDs of the users to retrieve. |
+
+>>> [!NOTE]
+>>> - The `user_ids` parameter should be an array of user IDs. You should include this parameter multiple times for each user ID you want to retrieve.
+>>> - The maximum number of user IDs you can retrieve at once is 50.
+>>> - Example: `?user_ids=123456789012345678&user_ids=234567890123456789`
+
+##### Response
+<details>
+<summary>
+  Example Response
+</summary>
+  
+  ```json
+  [
+    {
+      // User metadata object
+      "metadata": {
+        "id": "123456789012345678",
+        "username": "example",
+        "discriminator": "0",
+        "global_name": "example",
+        "avatar": "abcdef1234567890",
+        "avatar_url": "https://cdn.discordapp.com/avatars/123456789012345678/123456789012345678.png",
+        "display_avatar_url": "https://cdn.discordapp.com/avatars/123456789012345678/123456789012345678.png",
+        "bot": false,
+        "flags": {
+          "human_readable": ["Staff"],
+          "bitfield": 1
+        },
+        "monitoring_since": {
+          "unix": 1620000000,
+          "raw": "2021-05-03T00:00:00.000Z"
+        }
+      },
+      "status": "online",
+      // Active platforms object with current Spotify track
+      "active_platforms": {
+        "desktop": "online",
+        "mobile": "offline",
+        "web": "offline",
+        "spotify": {
+          "track_id": "abcdef1234567890",
+          "song": "example",
+          "artist": "example",
+          "album": "example",
+          "album_cover": "https://i.scdn.co/image/abcdef1234567890",
+          "start_time": {
+            "unix": 1620000000,
+            "raw": "2021-05-03T00:00:00.000Z"
+          },
+          "end_time": {
+            "unix": 1620000000,
+            "raw": "2021-05-03T00:00:00.000Z"
+          },
+          "time": {
+            "start_human_readable": "00:00",
+            "end_human_readable": "00:00"
+          }
+        }
+      },
+      // Array of user activities
+      "activities": [
+        {
+          "id": "abcdef1234567890",
+          "name": "example",
+          "type": "PLAYING",
+          "state": "example",
+          "details": "example",
+          "application_id": "123456789012345678",
+          "created_at": 1620000000,
+          "assets": {
+            "large_image": {
+              "hash": "abcdef1234567890",
+              "image_url": "https://cdn.discordapp.com/app-assets/123456789012345678/abcdef1234567890.png",
+              "text": "example"
+            },
+            "small_image": {
+              "hash": "abcdef1234567890",
+              "image_url": "https://cdn.discordapp.com/app-assets/123456789012345678/abcdef1234567890.png",
+              "text": "example"
+            }
+          },
+          "start_time": {
+            "unix": 1620000000,
+            "raw": "2021-05-03T00:00:00.000Z"
+          }
+        }
+      ],
+      // Key-value pairs for the user (if any)
+      "storage": {
+        "key": "value"
+      }
+    },
+    // Additional user objects
+  ]
+```
+</details>
 
 ##### GET `/api/v1/users/:id`
 

--- a/server/config.toml
+++ b/server/config.toml
@@ -6,6 +6,7 @@ required_environment_variables = [
 
 application_id = '1253067981832061001'
 base_guild_id = '1253092552404631582'
+max_bulk_get_users_size = 50
 
 [server]
 port = 3003

--- a/server/lib/express/routes/api/v1/users/index.js
+++ b/server/lib/express/routes/api/v1/users/index.js
@@ -1,0 +1,35 @@
+const User = require('@/models/User');
+const { query } = require('express-validator');
+const validateRequest = require('@/lib/express/middlewares/validateRequest');
+const createUserData = require('@/utils/createUserData');
+const Storage = require('@/models/Storage');
+
+module.exports = {
+  get: [
+    query('user_ids')
+      .exists().withMessage('user_ids is required.')
+      .isArray().withMessage('user_ids must be an array.')
+      .custom(value => value.every(id => typeof id === 'string' && id.length >= 17 && id.length <= 19)).withMessage('user_ids must be an array of strings with 17-19 characters long.')
+      .custom(value => value.length === new Set(value).size).withMessage('user_ids must not contain duplicates.'),
+    validateRequest,
+    async (request, response) => {
+      const { user_ids } = request.query;
+      
+      if (user_ids.length === config.max_bulk_get_users_size) return response.status(400).json({ error: `You can only request up to ${config.max_bulk_get_users_size} users at once.` });
+
+      const users = await User.find({ id: { $in: user_ids } }).lean();
+      
+      const notMonitoredUsers = user_ids.filter(id => !users.some(({ id: user_id }) => user_id === id));
+      if (notMonitoredUsers.length === user_ids.length) return response.status(404).json({ error: 'Users you requested are not monitored by Lantern.' });
+
+      const usersStorages = await Storage.find({ userId: { $in: user_ids } });
+
+      const createdUsersData = users.map(user => {
+        const user_storage = usersStorages.find(({ userId }) => userId === user.id);
+        return createUserData(user.id, user_storage?.kv || {});
+      });
+
+      return response.json(createdUsersData);
+    }
+  ]
+};


### PR DESCRIPTION
## Description
By adding user_ids query strings to the /users endpoint, data of multiple (maximum 50) people can be retrieved with a single request. This pull request makes this possible.

## Changes Made
[Add max_bulk_get_users_size configuration option](https://github.com/discordplace/lantern/commit/918dba1b6b1ccdc87fe2502be29434cf12f02dac)
[Add API endpoint for retrieving multıple users wıth one request](https://github.com/discordplace/lantern/commit/f44330ffebbec5c35cae352d531a22373c47f786)
[Document bulk get users endpoint](https://github.com/discordplace/lantern/commit/44380267494056b9d454e6ac1f49f0a72f2a85fa)

## Related Issues
N/A

## Screenshots (if applicable)
N/A

## Checklist
- [X] I have tested the changes locally.
- [X] I have reviewed my code for any potential issues.
- [X] I have checked for code style compliance.
- [X] I have added necessary labels and assigned reviewers.
- [X] I have squashed my commits into meaningful units.