### PR TITLE
Correctly handle simultaneous requests

### DIFF
--- a/server/lib/express/createServer.js
+++ b/server/lib/express/createServer.js
@@ -3,6 +3,7 @@ const compression = require('compression');
 const path = require('node:path');
 const { router } = require('express-file-routing');
 const morganMiddleware = require('@/lib/express/middlewares/morganMiddleware');
+const handleSimultaneousRequests = require('@/lib/express/middlewares/handleSimultaneousRequests');
 const ws = require('express-ws');
 
 async function createServer() {
@@ -25,6 +26,7 @@ async function createServer() {
   // Add middlewares
   app.use(morganMiddleware);
   app.use(compression());
+  app.use(handleSimultaneousRequests);
 
   // Add 'Access-Control-Allow-Origin' header to the response to allow CORS
   app.use((request, response, next) => {

--- a/server/lib/express/middlewares/handleSimultaneousRequests.js
+++ b/server/lib/express/middlewares/handleSimultaneousRequests.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const AsyncLock = require('async-lock');
 
 const lock = new AsyncLock({ timeout: 5000 });

--- a/server/lib/express/middlewares/handleSimultaneousRequests.js
+++ b/server/lib/express/middlewares/handleSimultaneousRequests.js
@@ -1,0 +1,33 @@
+const crypto = require('crypto');
+const AsyncLock = require('async-lock');
+
+const lock = new AsyncLock({ timeout: 5000 });
+
+const generateRequestKey = (request) => {
+  const { method, originalUrl, body } = request;
+  const bodyString = JSON.stringify(body); 
+  const requestIp = request.clientIp;
+
+  // Create an MD5 hash from the method, URL, body, and IP address
+  return crypto.createHash('md5').update(`${method}${originalUrl}${bodyString}${requestIp}`).digest('hex');
+};
+
+const handleSimultaneousRequests = async (request, response, next) => {
+  const requestKey = generateRequestKey(request);
+
+  try {
+    await lock.acquire(requestKey, async () => {
+      // Create a new promise that resolves when the response is finished or fails if there's an error
+      await new Promise((resolve, reject) => {
+        response.on('finish', resolve);
+        response.on('error', reject);
+        next();
+      });
+    });
+  } catch (error) {
+    response.status(500).json({ error: `Failed to process the request: ${error.message}` });
+    logger.error('There was an error while processing the request:', error);
+  }
+};
+
+module.exports = handleSimultaneousRequests;

--- a/server/package.json
+++ b/server/package.json
@@ -35,6 +35,7 @@
     "@iarna/toml": "^2.2.5",
     "@logtail/node": "^0.4.21",
     "@logtail/winston": "^0.4.21",
+    "async-lock": "^1.4.1",
     "axios": "^1.7.2",
     "body-parser": "^1.20.2",
     "chalk": "4.1.2",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@logtail/winston':
         specifier: ^0.4.21
         version: 0.4.21(winston@3.13.0)
+      async-lock:
+        specifier: ^1.4.1
+        version: 1.4.1
       axios:
         specifier: ^1.7.2
         version: 1.7.2
@@ -262,6 +265,9 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
   async@3.2.5:
     resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
@@ -1373,6 +1379,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
+
+  async-lock@1.4.1: {}
 
   async@3.2.5: {}
 


### PR DESCRIPTION
## Description
This pull request introduces middleware to block simultaneous requests to the server. It aims to prevent race conditions and improve the reliability of the API by ensuring that only one request with the same unique identifier is processed at a time. This is achieved using the AsyncLock library, which handles request locking based on a unique hash generated from request data.

## Changes Made
[Add handleSimultaneousRequests middleware](https://github.com/discordplace/lantern/commit/f47140ac05117a7d3a85f5de749baf63a70eaac7)
[Add handleSimultaneousRequests middleware to server](https://github.com/discordplace/lantern/commit/f54defc915b2e4489045d6c601325f576289c70c)
[Update npm dependencies to include async-lock package](https://github.com/discordplace/lantern/commit/ebbb9792ba6ffd9c9dc513057541206b23b25a77)
[Update crypto dependency to use node:crypto module](https://github.com/discordplace/lantern/commit/1fb465fde396c79e4293b174754d5d6a39485086)

## Related Issues
N/A

## Screenshots (if applicable)
N/A

## Checklist
- [X] I have tested the changes locally.
- [X] I have reviewed my code for any potential issues.
- [X] I have checked for code style compliance.
- [X] I have added necessary labels and assigned reviewers.
- [X] I have squashed my commits into meaningful units.