### PR TITLE
feat: Add GitHub Action for setting up Node environment

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -1,0 +1,29 @@
+name: "Setup Node Environment"
+description: "Setup Node, cache and clean install"
+
+inputs:
+  node-version:
+    description: "the Node.js version to use"
+    required: true
+  cache-path:
+    description: "path to cache folders and files"
+    required: true
+  cache-key:
+    description: "the key for caching"
+    required: true
+  project:
+    description: "the path to project"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{inputs.node-version}}
+    - uses: actions/cache@v4
+      with:
+        path: ${{inputs.cache-path}}
+        key: ${{inputs.cache-key}}
+    - run: npm ci --prefix ${{inputs.project}}
+      shell: bash


### PR DESCRIPTION
This pull request introduces a new GitHub Action to set up a Node.js environment, including caching and a clean install. The most important changes are as follows:

### GitHub Action for Node Environment Setup:

* [`.github/actions/setup-node-env/action.yml`](diffhunk://#diff-8fc5d4267ec6adb8c520d4a3cd87dd2c3026b516bc7fd7ba336dc697733c775dR1-R29): Added a new action named "Setup Node Environment" that includes inputs for `node-version`, `cache-path`, `cache-key`, and `project`. The action uses `actions/setup-node@v4` to set up Node.js, `actions/cache@v4` for caching, and runs `npm ci` for a clean install.