### PR TITLE
chore: update README to clarify server startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ base_guild_id = 'your_base_guild_id'
 port = 8000
 ```
 
-6. Start the server. This builds the client and starts the server in the production environment:
+6. Start the server. This builds the app and starts the server:
 
 ```bash
 pnpm start


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the instructions to clarify that the command builds the app, not just the client, before starting the server.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L838-R838): Updated step 6 instructions to specify that the command builds the app and starts the server.