### PR TITLE
feat(presence): implement last seen tracking for users

### DIFF
--- a/src/lib/bot/events/presenceUpdate.ts
+++ b/src/lib/bot/events/presenceUpdate.ts
@@ -1,12 +1,35 @@
 import createUserData from '@/utils/bot/createUserData';
 import { send as socket_send } from '@/express/routes/socket/utils';
 import Storage from '@/models/Storage';
+import User from '@/models/User';
 import type { EventType } from '@/src/types';
 
 export default {
   name: 'presenceUpdate',
-  execute: async (_, newPresence) => {
+  execute: async (oldPresence, newPresence) => {
     if (!newPresence.user) return;
+
+    if (oldPresence?.user) {
+      if (oldPresence.status !== 'offline' && newPresence.status === 'offline') {
+        await User.updateOne(
+          { id: newPresence.user.id },
+          { lastSeenAt: new Date() },
+          { upsert: true }
+        );
+
+        client.lastSeens.set(newPresence.user.id, new Date());
+      };
+
+      if (oldPresence.status === 'offline' && newPresence.status !== 'offline') {
+        await User.updateOne(
+          { id: newPresence.user.id },
+          { lastSeenAt: null },
+          { upsert: true }
+        );
+
+        client.lastSeens.delete(newPresence.user.id);
+      }
+    }
 
     // find if any socket is monitoring the user
     const anySocketMonitoring = [...ActiveSockets.values()]

--- a/src/lib/models/User.ts
+++ b/src/lib/models/User.ts
@@ -6,6 +6,11 @@ const User = new Schema({
   id: {
     type: String,
     required: true
+  },
+  lastSeenAt: {
+    type: Date,
+    required: false,
+    default: null
   }
 }, {
   versionKey: false

--- a/src/lib/utils/bot/createUserData.ts
+++ b/src/lib/utils/bot/createUserData.ts
@@ -126,7 +126,7 @@ function createUserData(user_id: string, kv: Map<string, string> | {}): UserData
     }
   }
 
-  return {
+  const baseObject = {
     metadata: {
       id: user_id,
       username: member.user.username,
@@ -146,11 +146,24 @@ function createUserData(user_id: string, kv: Map<string, string> | {}): UserData
         raw: member.joinedAt
       }
     },
-    status: member.presence?.status || 'offline',
     active_platforms: activePlatforms,
     activities: parsedActivites,
     storage: kv
   };
+
+  if (member.presence?.status === 'offline' && client.lastSeens.has(user_id)) {
+    return {
+      ...baseObject,
+      status: 'offline',
+      last_seen_at: client.lastSeens.get(user_id)
+    };
+  } else {
+    return {
+      ...baseObject,
+      status: member.presence?.status as Exclude<string, 'offline'>,
+      last_seen_at: null
+    };
+  }
 }
 
 export default createUserData;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -78,6 +78,7 @@ declare module 'discord.js' {
     commands: Discord.Collection<string, CommandType>;
     crons: Discord.Collection<string, CronType>;
     events: Discord.Collection<string, EventType>;
+    lastSeens: Discord.Collection<string, Date>;
   }
 
   interface CommandInteraction {
@@ -91,30 +92,33 @@ declare module 'discord.js' {
   }
 }
 
-export type UserData = {
+export type BaseUserType = {
   metadata: {
-    id: string,
-    username: string,
-    discriminator: string,
-    global_name: string | null,
-    avatar: string | null,
-    avatar_url: string | null,
-    display_avatar_url: string,
-    bot: boolean,
+    id: string;
+    username: string;
+    discriminator: string;
+    global_name: string | null;
+    avatar: string | null;
+    avatar_url: string | null;
+    display_avatar_url: string;
+    bot: boolean;
     flags: {
-      human_readable: string[],
-      bitfield: number | null | undefined
-    },
+      human_readable: string[];
+      bitfield: number | null | undefined;
+    };
     monitoring_since: {
-      unix: number | null,
-      raw: Date | null
-    }
-  },
-  status: string,
-  active_platforms: ClientPresenceStatusData,
-  activities: (CustomStatusActivity | OtherActivity)[],
-  storage: Map<string, string> | {}
-}
+      unix: number | null;
+      raw: Date | null;
+    };
+  };
+  active_platforms: ClientPresenceStatusData;
+  activities: (CustomStatusActivity | OtherActivity)[];
+  storage: Map<string, string> | {};
+};
+
+export type UserData =
+  | (BaseUserType & { status: 'offline'; last_seen_at: Date })
+  | (BaseUserType & { status: Exclude<string, 'offline'>; last_seen_at: null });
 
 export type ClientPresenceStatus = 'online' | 'idle' | 'dnd' | 'offline';
 


### PR DESCRIPTION
This pull request includes changes to improve the tracking of user presence and caching of their last seen dates in the bot system. The most important changes include adding a `lastSeenAt` field to the `User` model, updating the `createClient` function to cache last seen dates, modifying the `presenceUpdate` event to update the `lastSeenAt` field, and adjusting the `createUserData` function to include the last seen date in the user data.