### PR TITLE
feat(svg): add last seen info to svg cards with option to disable it

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Retrieve the data of a user with the specified ID.
 | `hideStatus` | number | Whether to hide the user's status. Must be either `0` or `1`. |
 | `hideBadges` | number | Whether to hide the user's badges. Must be either `0` or `1`. |
 | `hideActivity` | number | Whether to hide the user's activity. Must be either `0` or `1`. |
+| `hideLastSeen` | number | Whether to hide the user's last seen time. Must be either `0` or `1`. |
 | `noActivityTitle` | string | The title to display when the user has no activity. Default might be `No Activity`. Can't be greater than 64 characters. |
 | `noActivityMessage` | string | The message to display when the user has no activity. Default might be `This user is not currently doing anything.`. Can't be greater than 256 characters. |
 

--- a/src/lib/express/routes/api/v1/users/[user_id]/createSvg.ts
+++ b/src/lib/express/routes/api/v1/users/[user_id]/createSvg.ts
@@ -27,6 +27,7 @@ async function createSvg(userData: UserData, options: CreateSvgOptions = {}) {
     hideStatus: false,
     hideBadges: false,
     hideActivity: false,
+    hideLastSeen: false,
     noActivityTitle: 'No Activity',
     noActivityMessage: 'User is not currently doing anything.'
   };
@@ -198,11 +199,13 @@ async function createSvg(userData: UserData, options: CreateSvgOptions = {}) {
               flex-direction: column;
               gap: 0.25rem;
               margin-left: 27%;
+              width: 100%;
             ">
               <div style="
                 display: flex;
                 align-items: center;
                 gap: 0.5rem;
+                width: 100%;
               ">
                 <div style="
                   ${!options.hideGlobalName ? `
@@ -214,8 +217,24 @@ async function createSvg(userData: UserData, options: CreateSvgOptions = {}) {
                     font-weight: 600;
                     color: ${variables.colors.text.primary};
                   `}
+                  display: flex;
+                  align-items: center;
+                  justify-content: space-between;
+                  width: 100%;
                 ">
-                  @${he.escape(userData.metadata.username)}
+                  <span>
+                    @${he.escape(userData.metadata.username)}
+                  </span>
+
+                  ${userData.status === 'offline' && userData.last_seen_at && !options.hideLastSeen ? `
+                    <span style="
+                      font-size: 0.75rem;
+                      font-weight: 500;
+                      color: ${variables.colors.text.secondary};
+                    ">
+                      Last seen ${dateFns.formatDistance(new Date(userData.last_seen_at.unix), new Date(), { addSuffix: true })}
+                    </span>
+                  ` : ''}
                 </div>
 
                 ${!options.hideBadges ? `

--- a/src/lib/express/routes/api/v1/users/[user_id]/index.ts
+++ b/src/lib/express/routes/api/v1/users/[user_id]/index.ts
@@ -48,6 +48,11 @@ export const get = [
     .isNumeric().withMessage('hideActivity must be a number.')
     .isIn([0, 1]).withMessage('hideActivity must be either 0 or 1.')
     .toInt(),
+  query('hideLastSeen')
+    .optional()
+    .isNumeric().withMessage('hideLastSeen must be a number.')
+    .isIn([0, 1]).withMessage('hideLastSeen must be either 0 or 1.')
+    .toInt(),
   query('noActivityTitle')
     .optional()
     .isString().withMessage('noActivityTitle must be a string.')

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -198,6 +198,7 @@ export type APIUsersGETRequestQuery = {
   hideStatus?: string;
   hideBadges?: string;
   hideActivity?: string;
+  hideLastSeen?: string;
   noActivityTitle?: string;
   noActivityMessage?: string;
 }

--- a/swagger.json
+++ b/swagger.json
@@ -207,6 +207,16 @@
             }
           },
           {
+            "name": "hideLastSeen",
+            "in": "query",
+            "description": "Whether to hide the user's last seen date.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
             "name": "noActivityTitle",
             "in": "query",
             "description": "The title to display when the user has no activity.",


### PR DESCRIPTION
This pull request introduces a new feature to hide the user's last seen time across various parts of the application. The changes include updates to the documentation, API routes, and the SVG creation logic to support this new feature.

### New feature to hide the user's last seen time:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R163): Added a new parameter `hideLastSeen` to the user data retrieval documentation.
* `src/lib/express/routes/api/v1/users/[user_id]/createSvg.ts`: Updated the `createSvg` function to handle the new `hideLastSeen` option and added corresponding styling changes. ([src/lib/express/routes/api/v1/users/[user_id]/createSvg.tsR30](diffhunk://#diff-f1a47facf97413333a5478555c34e1b248adb18248e04b4c4c39327d118b5220R30), [src/lib/express/routes/api/v1/users/[user_id]/createSvg.tsR202-R208](diffhunk://#diff-f1a47facf97413333a5478555c34e1b248adb18248e04b4c4c39327d118b5220R202-R208), [src/lib/express/routes/api/v1/users/[user_id]/createSvg.tsR220-R237](diffhunk://#diff-f1a47facf97413333a5478555c34e1b248adb18248e04b4c4c39327d118b5220R220-R237))
* `src/lib/express/routes/api/v1/users/[user_id]/index.ts`: Added validation for the new `hideLastSeen` query parameter. ([src/lib/express/routes/api/v1/users/[user_id]/index.tsR51-R55](diffhunk://#diff-6e644c5abdc3d2dbc4a39b920a3073b0f6fc481ad4236540f37d1ad7026fa3f0R51-R55))
* [`swagger.json`](diffhunk://#diff-10cfbe600d3f92e886aea1d00df1367f9899549b1a3235442e5191b66ced7e71R209-R218): Updated the API documentation to include the new `hideLastSeen` query parameter.